### PR TITLE
Compatibility with kad@1.1.0-beta.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Setup
 -----
 
 ```
-npm install kad kad-webrtc
+npm install kad@1.1.0-beta.2 kad-webrtc
 ```
 
 Usage
@@ -19,9 +19,9 @@ var WebRTC = require('kad-webrtc');
 
 var dht = new Node({
   // ...
-  transport: WebRTC,
-  nick: 'mynickname',
-  signaller: SignalServer // see examples
+  transport: WebRTC({ nick: 'mynickname' }, {
+    signaller: SignalServer // see examples
+  })
 });
 
 dht.connect({ nick: 'somebody' }, function(err) {

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -17,19 +17,23 @@ inherits(WebRTCTransport, RPC);
 /**
 * Represents an RPC interface over WebRTC
 * @constructor
+* @param {object} contact
 * @param {object} options
 */
-function WebRTCTransport(options) {
+function WebRTCTransport(contact, options) {
   if (!(this instanceof WebRTCTransport)) {
-    return new WebRTCTransport(options);
+    return new WebRTCTransport(contact, options);
   }
 
-  assert(options instanceof Object, 'Invalid options were supplied');
-  assert(options.signaller instanceof Object, 'Invalid signaller was supplied');
+  assert(typeof options === 'object', 'Invalid options were supplied');
+  assert(
+    typeof options.signaller === 'object',
+    'Invalid signaller was supplied'
+  );
 
   var self = this;
 
-  RPC.call(this, options);
+  RPC.call(this, contact, options);
 
   this._peers = {};
   this._signaller = options.signaller;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "omphalos",
   "license": "GPL-3.0",
   "peerDependencies": {
-    "kad": "^0.9.x"
+    "kad": "^1.1.0-beta.2"
   },
   "dependencies": {
     "hat": "0.0.3",

--- a/test/transport.unit.js
+++ b/test/transport.unit.js
@@ -17,13 +17,13 @@ describe('Transports/WebRTC', function() {
 
     it('should create an instance with the `new` keyword', function() {
       var signaller = new EventEmitter();
-      var rpc = new RPC({ nick: 'a', signaller: signaller });
+      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
       expect(rpc).to.be.instanceOf(RPC);
     });
 
     it('should create an instance without the `new` keyword', function() {
       var signaller = new EventEmitter();
-      var rpc = RPC({ nick: 'a', signaller: signaller });
+      var rpc = RPC({ nick: 'a' }, { signaller: signaller });
       expect(rpc).to.be.instanceOf(RPC);
     });
 
@@ -35,21 +35,21 @@ describe('Transports/WebRTC', function() {
 
     it('should throw without signaller', function() {
       expect(function() {
-        RPC({ nick: 'a' });
+        RPC({ nick: 'a' }, {});
       }).to.throw(Error, 'Invalid signaller was supplied');
     });
 
     it('should bind to the signaller', function() {
       var signaller = new EventEmitter();
       var addListener = sinon.stub(signaller, 'addListener');
-      var rpc = new RPC({ nick: 'a', signaller: signaller });
+      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
       expect(addListener.callCount).to.equal(1);
       expect(addListener.calledWith('a', rpc._signalHandler)).to.equal(true);
     });
 
     it('should emit a ready event', function(done) {
       var signaller = new EventEmitter();
-      var rpc = new RPC({ nick: 'a', signaller: signaller });
+      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
       rpc.on('ready', done);
     });
   });
@@ -59,7 +59,7 @@ describe('Transports/WebRTC', function() {
     it('should create a new peer', function(done) {
       var signaller = new EventEmitter();
       var handshakeID = hat();
-      var rpc = new RPC({ nick: 'a', signaller: signaller });
+      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
       var neighbor = new SimplePeer({ wrtc: wrtc, initiator: true });
       neighbor.on('signal', function(signal) {
         var message = { signal: signal, handshakeID: handshakeID, sender: 'b' };
@@ -74,7 +74,7 @@ describe('Transports/WebRTC', function() {
     it('should signal a new peer', function() {
       var signaller = new EventEmitter();
       var handshakeID = hat();
-      var rpc = new RPC({ nick: 'a', signaller: signaller });
+      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
       var signalStub = sinon.stub();
       sinon.stub(rpc, '_createPeer', function() {
         return { once: sinon.stub(), signal: signalStub };
@@ -86,7 +86,7 @@ describe('Transports/WebRTC', function() {
     it('should signal an existing peer', function() {
       var signaller = new EventEmitter();
       var handshakeID = hat();
-      var rpc = new RPC({ nick: 'a', signaller: signaller });
+      var rpc = new RPC({ nick: 'a'}, { signaller: signaller });
       rpc._createPeer('a', handshakeID, true);
       var peer = rpc._peers[handshakeID];
       var signalStub = sinon.stub(peer, 'signal');
@@ -100,7 +100,7 @@ describe('Transports/WebRTC', function() {
 
     it('should forward the peer\'s signals to the signaller', function(done) {
       var signaller = new EventEmitter();
-      var rpc = new RPC({ nick: 'a', signaller: signaller });
+      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
       var handshakeID = hat();
       var peer = rpc._createPeer('b', handshakeID, true);
       signaller.once('b', function(message) {
@@ -112,7 +112,7 @@ describe('Transports/WebRTC', function() {
 
     it('should log the peer\'s errors', function() {
       var signaller = new EventEmitter();
-      var rpc = new RPC({ nick: 'a', signaller: signaller });
+      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
       var handshakeID = hat();
       var peer = rpc._createPeer('b', handshakeID, true);
       var error = sinon.stub(rpc._log, 'error');
@@ -125,7 +125,7 @@ describe('Transports/WebRTC', function() {
 
     it('should remove the peer\'s listeners when closed', function() {
       var signaller = new EventEmitter();
-      var rpc = new RPC({ nick: 'a', signaller: signaller });
+      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
       var handshakeID = hat();
       var peer = rpc._createPeer('b', handshakeID, true);
 
@@ -149,7 +149,7 @@ describe('Transports/WebRTC', function() {
 
     it('should add the peer to the collection', function() {
       var signaller = new EventEmitter();
-      var rpc = new RPC({ nick: 'a', signaller: signaller });
+      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
       var handshakeID = hat();
       var peer = rpc._createPeer('b', handshakeID, true);
       expect(rpc._peers[handshakeID]).to.equal(peer);
@@ -159,7 +159,7 @@ describe('Transports/WebRTC', function() {
   describe('#_createContact', function() {
     it('should create a WebRTCContact', function() {
       var signaller = new EventEmitter();
-      var rpc = new RPC({ nick: 'a', signaller: signaller });
+      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
       var contact = rpc._createContact({ nick: 'b' });
       expect(contact).to.be.instanceOf(WebRTCContact);
     });
@@ -172,8 +172,8 @@ describe('Transports/WebRTC', function() {
 
     before(function() {
       var signaller = new EventEmitter();
-      rpc1 = new RPC({ nick: 'a', signaller: signaller });
-      rpc2 = new RPC({ nick: 'b', signaller: signaller });
+      rpc1 = new RPC({ nick: 'a' }, { signaller: signaller });
+      rpc2 = new RPC({ nick: 'b' }, { signaller: signaller });
     });
 
     after(function() {
@@ -182,7 +182,9 @@ describe('Transports/WebRTC', function() {
     });
 
     it('should throw with invalid message', function() {
-      var contact = new WebRTCContact({ nick: 'b' });
+      var contact = new WebRTCContact({ nick: 'b' }, {
+        signaller: new EventEmitter()
+      });
       expect(function() {
         rpc1.send(contact, {});
       }).to.throw(Error, 'Invalid message supplied');
@@ -193,7 +195,10 @@ describe('Transports/WebRTC', function() {
       var addr2 = rpc2._contact;
       var contactRpc1 = new WebRTCContact(addr1);
       var contactRpc2 = new WebRTCContact(addr2);
-      var msg = new Message('PING', {}, contactRpc1);
+      var msg = new Message({
+        method: 'PING',
+        params: { contact: contactRpc1 }
+      });
       var handler = sinon.stub();
       rpc1.send(contactRpc2, msg, handler);
       var calls = Object.keys(rpc1._pendingCalls);
@@ -206,7 +211,10 @@ describe('Transports/WebRTC', function() {
       var addr2 = rpc2._contact;
       var contactRpc1 = new WebRTCContact(addr1);
       var contactRpc2 = new WebRTCContact(addr2);
-      var msg = new Message('PING', {}, contactRpc1);
+      var msg = new Message({
+        method: 'PING',
+        params: { contact: contactRpc1 }
+      });
       rpc2.send(contactRpc1, msg);
       var calls = Object.keys(rpc2._pendingCalls);
       expect(calls).to.have.lengthOf(0);
@@ -214,9 +222,12 @@ describe('Transports/WebRTC', function() {
 
     it('should transmit a message', function(done) {
       var signaller = new EventEmitter();
-      var rpc1 = new RPC({ nick: 'a', signaller: signaller });
-      var rpc2 = new RPC({ nick: 'b', signaller: signaller });
-      var message = new Message('PING', {}, rpc2._contact);
+      var rpc1 = new RPC({ nick: 'a' }, { signaller: signaller });
+      var rpc2 = new RPC({ nick: 'b' }, { signaller: signaller });
+      var message = new Message({
+        method: 'PING',
+        params: { contact: rpc2._contact }
+      });
       rpc1.once('PING', function() {
         done();
       });
@@ -229,7 +240,7 @@ describe('Transports/WebRTC', function() {
     it('should destroy the underlying peers', function() {
       var signaller = new EventEmitter();
       var handshakeID = hat();
-      var rpc = new RPC({ nick: 'a', signaller: signaller });
+      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
       rpc._createPeer('a', handshakeID, true);
       var peer = rpc._peers[handshakeID];
       var destroy = sinon.stub(peer, 'destroy');
@@ -241,7 +252,7 @@ describe('Transports/WebRTC', function() {
     it('should unsusbcribe from the signaller', function() {
       var signaller = new EventEmitter();
       var handshakeID = hat();
-      var rpc = new RPC({ nick: 'a', signaller: signaller });
+      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
       var removeListener = sinon.stub(signaller, 'removeListener');
       rpc._createPeer('a', handshakeID, true);
       rpc.close();
@@ -253,11 +264,18 @@ describe('Transports/WebRTC', function() {
   describe('#_handleMessage', function() {
 
     var contact1 = new WebRTCContact({ nick: 'a' });
-    var validMsg1 = Message('PING', { rpcID: 10 }, contact1).serialize();
-    var validMsg2 = Message('PONG', { referenceID: 10 }, contact1).serialize();
+    var validMsg1 = Message({
+      method: 'PING',
+      id: 10,
+      params: { contact: contact1}
+    }).serialize();
+    var validMsg2 = Message({
+      id: 10,
+      result: { contact: contact1 }
+    }).serialize();
     var invalidMsg = Buffer(JSON.stringify({ type: 'WRONG', params: {} }));
     var invalidJSON = Buffer('i am a bad message');
-    var rpc = new RPC({ nick: 'b', signaller: new EventEmitter() });
+    var rpc = new RPC({ nick: 'b' }, { signaller: new EventEmitter() });
 
     it('should drop the message if invalid JSON', function(done) {
       rpc.once('MESSAGE_DROP', function() {
@@ -285,7 +303,7 @@ describe('Transports/WebRTC', function() {
       rpc._pendingCalls[10] = {
         callback: function(err, params) {
           expect(err).to.equal(null);
-          expect(params.referenceID).to.equal(10);
+          expect(params.id).to.equal(10);
           done();
         }
       };
@@ -298,7 +316,7 @@ describe('Transports/WebRTC', function() {
 
     it('should call expired handler with error and remove it', function() {
       var signaller = new EventEmitter();
-      var rpc = new RPC({ nick: 'a', signaller: signaller });
+      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
       var freshHandler = sinon.stub();
       var staleHandler = sinon.spy();
       rpc._pendingCalls.rpc_id_1 = {
@@ -322,7 +340,7 @@ describe('Transports/WebRTC', function() {
 
     it('should clean up the peers', function() {
       var signaller = new EventEmitter();
-      var rpc = new RPC({ nick: 'a', signaller: signaller });
+      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
       var peer = rpc._createPeer();
       rpc._close();
       expect(peer.destroyed).to.equal(true);
@@ -331,7 +349,7 @@ describe('Transports/WebRTC', function() {
 
     it('should unsusbcribe from the signaller', function() {
       var signaller = new EventEmitter();
-      var rpc = new RPC({ nick: 'a', signaller: signaller });
+      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
       var removeListener = sinon.stub(signaller, 'removeListener');
       rpc._close();
       expect(removeListener.calledWith('a', rpc._signalHandler)).to.equal(true);


### PR DESCRIPTION
This PR includes updates for compatibility with Kad's newer `RPC` interface and also updates the tests for compatibility with the move from Kad's older custom `Message` format to JSON-RPC.

Relevant:

* [`kad.RPC` documentation](https://github.com/gordonwritescode/kad/blob/master/doc/rpc.md)
* [`kad.Message` documentation](https://github.com/gordonwritescode/kad/blob/master/doc/message.md)
 
> Note: the examples have not been updated.