### PR TITLE
Upgrade for compatibility with kad@1.2.0-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Setup
 -----
 
 ```
-npm install kad@1.1.0-beta.2 kad-webrtc
+npm install kad@1.2.0-beta kad-webrtc
 ```
 
 Usage
@@ -19,7 +19,7 @@ var WebRTC = require('kad-webrtc');
 
 var dht = new Node({
   // ...
-  transport: WebRTC({ nick: 'mynickname' }, {
+  transport: WebRTC(WebRTC.Contact({ nick: 'mynickname' }), {
     signaller: SignalServer // see examples
   })
 });
@@ -36,4 +36,3 @@ To build the examples, run `npm run build-examples`.
 
 After that, look at the READMEs in each example directory
 to see how to run them.
-

--- a/examples/webrtc-browser-e2e/index.js
+++ b/examples/webrtc-browser-e2e/index.js
@@ -12,13 +12,17 @@ webSocket.on('open', function() {
 
   // Create our first node
   var node1 = new kademlia.Node({
-    transport: new WebRTC({ nick: 'node1' }, { signaller: signalClient1 }),
+    transport: new WebRTC(new WebRTC.Contact({
+      nick: 'node1'
+    }), { signaller: signalClient1 }),
     storage: new kademlia.storage.LocalStorage('node1')
   });
 
   // Create a second node
   var node2 = new kademlia.Node({
-    transport: new WebRTC({ nick: 'node2' }, { signaller: signalClient2 }),
+    transport: new WebRTC(new WebRTC.Contact({
+      nick: 'node2'
+    }), { signaller: signalClient2 }),
     storage: new kademlia.storage.LocalStorage('node2')
   });
 

--- a/examples/webrtc-browser/index.js
+++ b/examples/webrtc-browser/index.js
@@ -9,13 +9,17 @@ var signaller = new EventEmitter();
 
 // Create our first node
 var node1 = new kademlia.Node({
-  transport: new WebRTC({ nick: 'node1' }, { signaller: signaller }),
+  transport: new WebRTC(new WebRTC.Contact({
+    nick: 'node1'
+  }), { signaller: signaller }),
   storage: new kademlia.storage.LocalStorage('node1')
 });
 
 // Create a second node
 var node2 = new kademlia.Node({
-  transport: new WebRTC({ nick: 'node2' }, { signaller: signaller }),
+  transport: new WebRTC(new WebRTC.Contact({
+    nick: 'node2'
+  }), { signaller: signaller }),
   storage: new kademlia.storage.LocalStorage('node2')
 });
 

--- a/examples/webrtc-node/index.js
+++ b/examples/webrtc-node/index.js
@@ -13,7 +13,9 @@ var signaller = new EventEmitter();
 
 // Create our first node
 var node1 = new kademlia.Node({
-  transport: WebRTC({ nick: 'node1' }, {
+  transport: WebRTC(new WebRTC.Contact({
+    nick: 'node1'
+  }), {
     signaller: signaller,
     wrtc: wrtc // When running in Node, we have to pass the wrtc package
   }),
@@ -22,7 +24,9 @@ var node1 = new kademlia.Node({
 
 // Create a second node
 var node2 = new kademlia.Node({
-  transport: WebRTC({ nick: 'node2' }, {
+  transport: WebRTC(new WebRTC.Contact({
+    nick: 'node2'
+  }), {
     signaller: signaller,
     wrtc: wrtc // When running in Node, we have to pass the wrtc package
   }),

--- a/index.js
+++ b/index.js
@@ -5,3 +5,4 @@
 'use strict';
 
 module.exports = require('./lib/transport');
+module.exports.Contact = require('./lib/contact');

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -25,23 +25,32 @@ function WebRTCTransport(contact, options) {
     return new WebRTCTransport(contact, options);
   }
 
+  assert(contact instanceof WebRTCContact, 'Invalid contact supplied');
   assert(typeof options === 'object', 'Invalid options were supplied');
   assert(
     typeof options.signaller === 'object',
     'Invalid signaller was supplied'
   );
 
-  var self = this;
+  this._signaller = options.signaller;
 
   RPC.call(this, contact, options);
+}
 
+/**
+* Setup WebRTC transport
+* #_open
+* @param {function} ready
+*/
+WebRTCTransport.prototype._open = function(ready) {
   this._peers = {};
-  this._signaller = options.signaller;
   this._signalHandler = this._onSignal.bind(this);
   this._signaller.addListener(this._contact.nick, this._signalHandler);
 
-  setTimeout(this.emit.bind(this, 'ready'));
-}
+  setTimeout(function() {
+    ready();
+  });
+};
 
 /**
 * Handle a message sent through `_signaller` from another peer
@@ -57,19 +66,10 @@ WebRTCTransport.prototype._onSignal = function(signallerMessage) {
   if(!peer) {
     peer = this._createPeer(sender, handshakeID, false);
     peer.once('data', function(data) {
-      self._handleMessage(data, { nick: signallerMessage.sender });
+      self.receive(data, { nick: signallerMessage.sender });
     });
   }
   peer.signal(signal);
-};
-
-/**
-* Create a WebRTC Contact
-* #_createContact
-* @param {object} options
-*/
-WebRTCTransport.prototype._createContact = function(options) {
-  return new WebRTCContact(options);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kad-webrtc",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "webrtc transport for kad",
   "main": "index.js",
   "directories": {
@@ -22,7 +22,7 @@
   "author": "omphalos",
   "license": "GPL-3.0",
   "peerDependencies": {
-    "kad": "^1.1.0-beta.2"
+    "kad": "1.2.0-beta"
   },
   "repository": {
     "type": "git",

--- a/test/transport.unit.js
+++ b/test/transport.unit.js
@@ -17,39 +17,39 @@ describe('Transports/WebRTC', function() {
 
     it('should create an instance with the `new` keyword', function() {
       var signaller = new EventEmitter();
-      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
+      var rpc = new RPC(WebRTCContact({ nick: 'a' }), { signaller: signaller });
       expect(rpc).to.be.instanceOf(RPC);
     });
 
     it('should create an instance without the `new` keyword', function() {
       var signaller = new EventEmitter();
-      var rpc = RPC({ nick: 'a' }, { signaller: signaller });
+      var rpc = RPC(WebRTCContact({ nick: 'a' }), { signaller: signaller });
       expect(rpc).to.be.instanceOf(RPC);
     });
 
     it('should throw without options', function() {
       expect(function() {
         RPC(null);
-      }).to.throw(Error, 'Invalid options were supplied');
+      }).to.throw(Error, 'Invalid contact supplied');
     });
 
     it('should throw without signaller', function() {
       expect(function() {
-        RPC({ nick: 'a' }, {});
+        RPC(WebRTCContact({ nick: 'a' }), {});
       }).to.throw(Error, 'Invalid signaller was supplied');
     });
 
     it('should bind to the signaller', function() {
       var signaller = new EventEmitter();
       var addListener = sinon.stub(signaller, 'addListener');
-      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
+      var rpc = new RPC(WebRTCContact({ nick: 'a' }), { signaller: signaller });
       expect(addListener.callCount).to.equal(1);
       expect(addListener.calledWith('a', rpc._signalHandler)).to.equal(true);
     });
 
     it('should emit a ready event', function(done) {
       var signaller = new EventEmitter();
-      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
+      var rpc = new RPC(WebRTCContact({ nick: 'a' }), { signaller: signaller });
       rpc.on('ready', done);
     });
   });
@@ -59,7 +59,7 @@ describe('Transports/WebRTC', function() {
     it('should create a new peer', function(done) {
       var signaller = new EventEmitter();
       var handshakeID = hat();
-      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
+      var rpc = new RPC(WebRTCContact({ nick: 'a' }), { signaller: signaller });
       var neighbor = new SimplePeer({ wrtc: wrtc, initiator: true });
       neighbor.on('signal', function(signal) {
         var message = { signal: signal, handshakeID: handshakeID, sender: 'b' };
@@ -74,7 +74,7 @@ describe('Transports/WebRTC', function() {
     it('should signal a new peer', function() {
       var signaller = new EventEmitter();
       var handshakeID = hat();
-      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
+      var rpc = new RPC(WebRTCContact({ nick: 'a' }), { signaller: signaller });
       var signalStub = sinon.stub();
       sinon.stub(rpc, '_createPeer', function() {
         return { once: sinon.stub(), signal: signalStub };
@@ -86,7 +86,7 @@ describe('Transports/WebRTC', function() {
     it('should signal an existing peer', function() {
       var signaller = new EventEmitter();
       var handshakeID = hat();
-      var rpc = new RPC({ nick: 'a'}, { signaller: signaller });
+      var rpc = new RPC(WebRTCContact({ nick: 'a'}), { signaller: signaller });
       rpc._createPeer('a', handshakeID, true);
       var peer = rpc._peers[handshakeID];
       var signalStub = sinon.stub(peer, 'signal');
@@ -100,7 +100,7 @@ describe('Transports/WebRTC', function() {
 
     it('should forward the peer\'s signals to the signaller', function(done) {
       var signaller = new EventEmitter();
-      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
+      var rpc = new RPC(WebRTCContact({ nick: 'a' }), { signaller: signaller });
       var handshakeID = hat();
       var peer = rpc._createPeer('b', handshakeID, true);
       signaller.once('b', function(message) {
@@ -112,7 +112,7 @@ describe('Transports/WebRTC', function() {
 
     it('should log the peer\'s errors', function() {
       var signaller = new EventEmitter();
-      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
+      var rpc = new RPC(WebRTCContact({ nick: 'a' }), { signaller: signaller });
       var handshakeID = hat();
       var peer = rpc._createPeer('b', handshakeID, true);
       var error = sinon.stub(rpc._log, 'error');
@@ -125,7 +125,7 @@ describe('Transports/WebRTC', function() {
 
     it('should remove the peer\'s listeners when closed', function() {
       var signaller = new EventEmitter();
-      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
+      var rpc = new RPC(WebRTCContact({ nick: 'a' }), { signaller: signaller });
       var handshakeID = hat();
       var peer = rpc._createPeer('b', handshakeID, true);
 
@@ -149,7 +149,7 @@ describe('Transports/WebRTC', function() {
 
     it('should add the peer to the collection', function() {
       var signaller = new EventEmitter();
-      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
+      var rpc = new RPC(WebRTCContact({ nick: 'a' }), { signaller: signaller });
       var handshakeID = hat();
       var peer = rpc._createPeer('b', handshakeID, true);
       expect(rpc._peers[handshakeID]).to.equal(peer);
@@ -159,7 +159,7 @@ describe('Transports/WebRTC', function() {
   describe('#_createContact', function() {
     it('should create a WebRTCContact', function() {
       var signaller = new EventEmitter();
-      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
+      var rpc = new RPC(WebRTCContact({ nick: 'a' }), { signaller: signaller });
       var contact = rpc._createContact({ nick: 'b' });
       expect(contact).to.be.instanceOf(WebRTCContact);
     });
@@ -172,8 +172,8 @@ describe('Transports/WebRTC', function() {
 
     before(function() {
       var signaller = new EventEmitter();
-      rpc1 = new RPC({ nick: 'a' }, { signaller: signaller });
-      rpc2 = new RPC({ nick: 'b' }, { signaller: signaller });
+      rpc1 = new RPC(WebRTCContact({ nick: 'a' }), { signaller: signaller });
+      rpc2 = new RPC(WebRTCContact({ nick: 'b' }), { signaller: signaller });
     });
 
     after(function() {
@@ -222,8 +222,8 @@ describe('Transports/WebRTC', function() {
 
     it('should transmit a message', function(done) {
       var signaller = new EventEmitter();
-      var rpc1 = new RPC({ nick: 'a' }, { signaller: signaller });
-      var rpc2 = new RPC({ nick: 'b' }, { signaller: signaller });
+      var rpc1 = new RPC(WebRTCContact({ nick: 'a' }), { signaller: signaller });
+      var rpc2 = new RPC(WebRTCContact({ nick: 'b' }), { signaller: signaller });
       var message = new Message({
         method: 'PING',
         params: { contact: rpc2._contact }
@@ -240,7 +240,7 @@ describe('Transports/WebRTC', function() {
     it('should destroy the underlying peers', function() {
       var signaller = new EventEmitter();
       var handshakeID = hat();
-      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
+      var rpc = new RPC(WebRTCContact({ nick: 'a' }), { signaller: signaller });
       rpc._createPeer('a', handshakeID, true);
       var peer = rpc._peers[handshakeID];
       var destroy = sinon.stub(peer, 'destroy');
@@ -252,7 +252,7 @@ describe('Transports/WebRTC', function() {
     it('should unsusbcribe from the signaller', function() {
       var signaller = new EventEmitter();
       var handshakeID = hat();
-      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
+      var rpc = new RPC(WebRTCContact({ nick: 'a' }), { signaller: signaller });
       var removeListener = sinon.stub(signaller, 'removeListener');
       rpc._createPeer('a', handshakeID, true);
       rpc.close();
@@ -261,7 +261,7 @@ describe('Transports/WebRTC', function() {
     });
   });
 
-  describe('#_handleMessage', function() {
+  describe('#receive', function() {
 
     var contact1 = new WebRTCContact({ nick: 'a' });
     var validMsg1 = Message({
@@ -275,20 +275,20 @@ describe('Transports/WebRTC', function() {
     }).serialize();
     var invalidMsg = Buffer(JSON.stringify({ type: 'WRONG', params: {} }));
     var invalidJSON = Buffer('i am a bad message');
-    var rpc = new RPC({ nick: 'b' }, { signaller: new EventEmitter() });
+    var rpc = new RPC(WebRTCContact({ nick: 'b' }), { signaller: new EventEmitter() });
 
     it('should drop the message if invalid JSON', function(done) {
       rpc.once('MESSAGE_DROP', function() {
         done();
       });
-      rpc._handleMessage(invalidJSON, {});
+      rpc.receive(invalidJSON, {});
     });
 
     it('should drop the message if invalid message type', function(done) {
       rpc.once('MESSAGE_DROP', function() {
         done();
       });
-      rpc._handleMessage(invalidMsg, {});
+      rpc.receive(invalidMsg, {});
     });
 
     it('should emit the message type if not a reply', function(done) {
@@ -296,7 +296,7 @@ describe('Transports/WebRTC', function() {
         expect(typeof data).to.equal('object');
         done();
       });
-      rpc._handleMessage(validMsg1, { address: '127.0.0.1', port: 1234 });
+      rpc.receive(validMsg1, { address: '127.0.0.1', port: 1234 });
     });
 
     it('should call the message callback if a reply', function(done) {
@@ -307,7 +307,7 @@ describe('Transports/WebRTC', function() {
           done();
         }
       };
-      rpc._handleMessage(validMsg2, { address: '127.0.0.1', port: 1234 });
+      rpc.receive(validMsg2, { address: '127.0.0.1', port: 1234 });
     });
 
   });
@@ -316,7 +316,7 @@ describe('Transports/WebRTC', function() {
 
     it('should call expired handler with error and remove it', function() {
       var signaller = new EventEmitter();
-      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
+      var rpc = new RPC(WebRTCContact({ nick: 'a' }), { signaller: signaller });
       var freshHandler = sinon.stub();
       var staleHandler = sinon.spy();
       rpc._pendingCalls.rpc_id_1 = {
@@ -340,7 +340,7 @@ describe('Transports/WebRTC', function() {
 
     it('should clean up the peers', function() {
       var signaller = new EventEmitter();
-      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
+      var rpc = new RPC(WebRTCContact({ nick: 'a' }), { signaller: signaller });
       var peer = rpc._createPeer();
       rpc._close();
       expect(peer.destroyed).to.equal(true);
@@ -349,7 +349,7 @@ describe('Transports/WebRTC', function() {
 
     it('should unsusbcribe from the signaller', function() {
       var signaller = new EventEmitter();
-      var rpc = new RPC({ nick: 'a' }, { signaller: signaller });
+      var rpc = new RPC(WebRTCContact({ nick: 'a' }), { signaller: signaller });
       var removeListener = sinon.stub(signaller, 'removeListener');
       rpc._close();
       expect(removeListener.calledWith('a', rpc._signalHandler)).to.equal(true);


### PR DESCRIPTION
The last in a series of API modifications in preparation for a stable `1.x.x` release of Kad.

* Transport adapter now must implement an `_open(readyCallback)` method to perform transport setup instead of implementing such logic in the constuctor
* Transport adapter no longer implements `_createContact`, instead this is handled in the base `RPC` class by using the constructor from the `Contact` object the adapter was initialized with
* Transport adapters now require that an *instance* of the required `Contact` object be supplied to the constructor - this allows users to extend `Contact` objects and remain compatible
  * (as a result of this, the included `Contact` constructor must be exposed from the module
* The base `RPC` class renamed `_handleMessage()` to `receive()` to improve clarity for implementors and align with the new "hooks" interface

Closes #3